### PR TITLE
Fix incorrect palette colors

### DIFF
--- a/ColorHarmony/colorHarmony.py
+++ b/ColorHarmony/colorHarmony.py
@@ -27,7 +27,7 @@ def image_result(colors, size, filename):
         palette[:, c * size:c * size + size, 2] = colors[c][2]  # blue
 
     filename = filename + "_colors.png"
-    im = Image.fromarray((palette* 255).astype('uint8'), 'RGB')
+    im = Image.fromarray((palette).astype('uint8'), 'RGB')
     im.save(filename, "PNG")
     print("Saved palette as", filename)
 


### PR DESCRIPTION
Removed the *255. The palette is already in 0-255 and not a float at this point, so the multiplication wraps around and inverts the colors.